### PR TITLE
add `RefrEnv_ResetPath` environment variable to allow reset the PATH for CMD and Powershell

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# RefrEnv - *Refr*esh the *Env*ironment
+# RefrEnv - **Refr**esh the **Env**ironment
 Reload environment variables inside `CMD`, `Bash`, `Powershell` or `Zsh` every time you want environment changes to propagate, so you do not need to restart them after setting a new variable with setx or after installing a new app which adds new variables.
 
-This is a better alternative to the chocolatey refreshenv for cmd (and works for `bash` and `zsh` too (`cygwin`, `Msys2` and `GitBash`)), which solves several problems in the chocolatey refreshenv, like:
+This is a better alternative to the `Chocolatey` `refreshenv` for cmd (and works for `bash` and `zsh` too (`cygwin`, `Msys2` and `GitBash`)), which solves several problems in the chocolatey's refreshenv, like:
  - The Chocolatey **refreshenv** act **bad** if the variable have some
    cmd meta-characters, see this test:
    
@@ -10,24 +10,26 @@ This is a better alternative to the chocolatey refreshenv for cmd (and works for
    `baaaaaaaaaad` which is very bad, and the new path is not added to
    your path variable.
    
-   `RefrEnv` solve this and you can test it with any meta-character, even something so bad like: 
+   `RefrEnv` solves this and you can test it with any meta-character, even something so bad like: 
    ```
    ; & % ' ( ) ~ + @ # $ { } [ ] , ` ! ^ | > < \ / " : ? * = . - _ & echo baaaad
    ```
- - refreshenv adds only **system** and **user**
+ - `refreshenv` adds only **system** and **user**
    environment variables, but CMD adds **volatile** variables too
    (HKCU\Volatile Environment). `RefrEnv` will merge all the three and
    **remove any duplicates**.
 
- - refreshenv reset your PATH. `RefrEnv` append the new path to the
+ - `refreshenv` resets your PATH. `RefrEnv` appends the new path to the
    old path of the parent script which called `RefrEnv`. It is better
    than overwriting the old path, otherwise it will delete any newly
-   added path by the parent script.
+   added path by the parent script. (this can be changed by user choice
+   to reset the path, see the description)
 
  - `RefrEnv` solve this problem described in a comment [here][1] by @Gene Mayevsky: 
      > refreshenv *modifies env variables TEMP and TMP replacing them with values stored in HKCU\Environment. In my case I run the script to update env variables modified by Jenkins job on a slave that's running under SYSTEM account, so TEMP and TMP get substituted by %USERPROFILE%\AppData\Local\Temp instead of C:\Windows\Temp. This breaks build because linker cannot open system profile's Temp folder.*
 
-[more info][2]
+and more...
+
 
 # Usage:
 ```batch
@@ -57,7 +59,59 @@ source refrenv.sh
 ```bash
 source refrenvz.sh
 ```
-#### Opciones for RefrEnv in bash and zsh 
+
+______
+# Details:
+## Opciones for RefrEnv in CMD 
+```
+NAME
+   RefrEnv - Refresh the Environment for CMD
+
+SYNOPSIS
+   call refrenv.bat
+
+DESCRIPTION
+   By default with no arguments, this script will do a full 
+   refresh (refresh all non critical variables*, and refresh the PATH).
+
+   you can use the following variables to change the default behaviour:
+
+   RefrEnv_ResetPath=yes       Reset the actual PATH inside CMD, then refresh
+                               it with a new PATH. This will delete any PATH 
+                               added by the script who called RefrEnv. It is 
+                               equivalent to running a new CMD session.
+
+   RefrEnv_debug=yes           Debug what this script do. The folder containing
+                               the files used to set the variables will be
+                               open, then see _NewEnv.sh, this is the file
+                               which run inside your script to setup the new
+                               variables, you can also revise the intermediate
+                               .txt files.
+```
+
+
+## Opciones for RefrEnv in Powershell 
+```
+NAME
+    RefrEnv - Refresh the Environment for Powershell/Pwsh
+
+SYNOPSIS
+    . .\refrenv.ps1
+    
+DESCRIPTION
+    By default with no arguments, this script will do a full 
+    refresh (refresh all non critical variables*, and refresh the PATH).
+
+    you can use the following variables to change the default behaviour:
+                                
+    RefrEnv_ResetPath=yes       Reset the actual PATH inside Powershell, then refresh
+                                it with a new PATH. This will delete any PATH 
+                                added by the script who called RefrEnv. It is 
+                                equivalent to running a new Powershell session.
+```
+
+
+## Opciones for RefrEnv in Bash and Zsh 
 ```
 SYNOPSIS
     source refrenv.sh
@@ -67,7 +121,7 @@ DESCRIPTION
     By default with no arguments, RefrEnv will do a full 
     refresh (refresh all non critical variables*, and refresh the PATH).
 
-    use can use the following variables to change some behaviours:
+    you can use the following variables to change the default behaviour:
     
     RefrEnv_StrictRefresh=yes   Strict mode (secure refresh). this prevent refreshing a
                                 variable if it is already defined in the actual bash/zsh session. 
@@ -85,17 +139,51 @@ DESCRIPTION
                               
     RefrEnv_help=yes            Print the help.
 
-    *critical variables: are the built-in variables which belong to bash/zsh or windows and should 
-    not be refreshed normally like:
-    - windows vars: ALLUSERSPROFILE APPDATA CommonProgramFiles ...
-    - bash/zsh vars: BASH BASHOPTS BASHPID BASH_ALIASES BASH_ARGC ...
-    
-    
+        
     RefrEnv support the so called bash Strict Mode like: "set -eEu -o pipefail ; shopt -s inherit_errexit"
     you can use the Strict Mode safely in your parent script without worry.
 
 ```
+ ______
+> [!NOTE]
+> __*critical variables__: are the built-in variables which belong to cmd/bash/zsh or windows and should not be refreshed normally like:
+
+<details>
+    <summary>Expand for details</summary>
  
+    - windows vars:
+        ALLUSERSPROFILE APPDATA CommonProgramFiles CommonProgramFiles(x86)
+        CommonProgramW6432 COMPUTERNAME ComSpec HOMEDRIVE HOMEPATH LOCALAPPDATA 
+        LOGONSERVER NUMBER_OF_PROCESSORS OS PATHEXT PROCESSOR_ARCHITECTURE 
+        PROCESSOR_ARCHITEW6432 PROCESSOR_IDENTIFIER PROCESSOR_LEVEL 
+        PROCESSOR_REVISION ProgramData ProgramFiles ProgramFiles(x86) 
+        ProgramW6432 PUBLIC SystemDrive SystemRoot TEMP TMP USERDOMAIN 
+        USERDOMAIN_ROAMINGPROFILE USERNAME USERPROFILE windir SESSIONNAME
+        
+    - bash vars:
+        BASH BASHOPTS BASHPID BASH_ALIASES BASH_ARGC BASH_ARGV BASH_CMDS 
+        BASH_COMMAND BASH_COMPLETION_VERSINFO BASH_LINENO BASH_REMATCH 
+        BASH_SOURCE BASH_SUBSHELL BASH_VERSINFO BASH_VERSION COLUMNS 
+        COMP_WORDBREAKS CYGWIN CYG_SYS_BASHRC DIRSTACK EUID EXECIGNORE 
+        FUNCNAME GROUPS HISTCMD HISTCONTROL HISTFILE HISTFILESIZE HISTSIZE 
+        HISTTIMEFORMAT HOME HOSTNAME HOSTTYPE IFS INFOPATH LANG LC_ALL 
+        LC_COLLATE LC_CTYPE LC_MESSAGES LC_MONETARY LC_NUMERIC LC_TIME LINENO 
+        LINES MACHTYPE MAILCHECK OLDPWD OPTERR OPTIND ORIGINAL_PATH OSTYPE PATH 
+        PIPESTATUS POSIXLY_CORRECT PPID PRINTER PROFILEREAD PROMPT_COMMAND PS0 
+        PS1 PS2 PS3 PS4 PWD RANDOM SECONDS SHELL SHELLOPTS SHLVL SSH_ASKPASS 
+        TERM TERM_PROGRAM TERM_PROGRAM_VERSION TZ UID USER _backup_glob 
+        CHILD_MAX BASH_COMPAT FUNCNEST COMP_TYPE COMP_KEY READLINE_LINE_BUFFER 
+        READLINE_POINT PROMPT_DIRTRIM BASH_EXECUTION_STRING COPROC_PID COPROC 
+        GLOBIGNORE HISTIGNORE SRANDOM READLINE_MARK EPOCHSECONDS EPOCHREALTIME 
+        BASH_ARGV0 COMPREPLY COMP_CWORD COMP_LINE COMP_POINT COMP_WORDS EMACS 
+        FCEDIT FIGNORE HOSTFILE IGNOREEOF INPUTRC INSIDE_EMACS MAPFILE 
+        READLINE_LINE REPLY TIMEFORMAT TMOUT TMPDIR histchars
+</details>
+
+<br>
+<br>
+RefrEnv was created to respond to this [Stackoverflow thread][2]
+
 
 
   [1]: https://stackoverflow.com/questions/171588/is-there-a-command-to-refresh-environment-variables-from-the-command-prompt-in-w

--- a/README.md
+++ b/README.md
@@ -182,10 +182,8 @@ DESCRIPTION
 
 <br>
 <br>
-RefrEnv was created to respond to this [Stackoverflow thread][2]
-
+RefrEnv was created to respond to this Stackoverflow thread: https://stackoverflow.com/questions/171588/is-there-a-command-to-refresh-environment-variables-from-the-command-prompt-in-w
 
 
   [1]: https://stackoverflow.com/questions/171588/is-there-a-command-to-refresh-environment-variables-from-the-command-prompt-in-w
-  [2]: https://stackoverflow.com/questions/171588/is-there-a-command-to-refresh-environment-variables-from-the-command-prompt-in-w
 

--- a/TODO
+++ b/TODO
@@ -1,0 +1,2 @@
+# TODO
+- add HKCU\Volatile Environment to powershell version

--- a/TODO
+++ b/TODO
@@ -1,2 +1,4 @@
 # TODO
-- add HKCU\Volatile Environment to powershell version
+- add "HKCU\Volatile Environment" to the powershell version
+- do i need to exclude some special powershell env like i did in bash?
+- add https://github.com/marketplace/actions/check-spelling

--- a/refrenv.bat
+++ b/refrenv.bat
@@ -3,23 +3,36 @@
 REM PUSHD "%~dp0"
 
 
-REM author: Badr Elmers 2021-2023
-REM description: refrenv = refresh environment. this is a better alternative to the chocolatey refreshenv for cmd
-REM version: 1.0
+REM author: Badr Elmers 2021-2024
+REM version: 1.1
 REM https://github.com/badrelmers/RefrEnv
-REM https://stackoverflow.com/questions/171588/is-there-a-command-to-refresh-environment-variables-from-the-command-prompt-in-w
+
 
 REM ___USAGE_____________________________________________________________
-REM usage: 
-REM        call refrenv.bat        full refresh. refresh all non critical variables*, and refresh the PATH
 
-REM debug:
-REM        to debug what this script do create this variable in your parent script like that
-REM        set debugme=yes
-REM        then the folder containing the files used to set the variables will be open. Then see
-REM        _NewEnv.cmd this is the file which run inside your script to setup the new variables, you
-REM        can also revise the intermediate files _NewEnv.cmd_temp_.cmd and _NewEnv.cmd_temp2_.cmd 
-REM        (those two contains all the variables before removing the duplicates and the unwanted variables)
+REM NAME
+REM    RefrEnv - Refresh the Environment for CMD
+REM
+REM SYNOPSIS
+REM    call refrenv.bat
+REM 
+REM DESCRIPTION
+REM    By default with no arguments, this script will do a full 
+REM    refresh (refresh all non critical variables*, and refresh the PATH).
+REM
+REM    you can use the following variables to change the default behaviour:
+REM
+REM    RefrEnv_ResetPath=yes       Reset the actual PATH inside CMD, then refresh
+REM                                it with a new PATH. This will delete any PATH 
+REM                                added by the script who called RefrEnv. It is 
+REM                                equivalent to running a new CMD session.
+REM
+REM    RefrEnv_debug=yes           Debug what this script do. The folder containing
+REM                                the files used to set the variables will be
+REM                                open, then see _NewEnv.sh, this is the file
+REM                                which run inside your script to setup the new
+REM                                variables, you can also revise the intermediate
+REM                                .txt files.
 
 
 REM you can also put this script in windows\systems32 or another place in your %PATH% then call it from an interactive console by writing refrenv
@@ -93,7 +106,7 @@ REM :: The only restriction is the VBS code cannot contain </script>.
 REM :: The only risk is the undocumented use of "%~f0?.wsf" as the script to load. Somehow the parser properly finds and loads the running .BAT script "%~f0", and the ?.wsf suffix mysteriously instructs CSCRIPT to interpret the script as WSF. Hopefully MicroSoft will never disable that "feature".
 REM :: https://stackoverflow.com/questions/9074476/is-it-possible-to-embed-and-execute-vbscript-within-a-batch-file-without-using-a
 
-if "%debugme%"=="yes" (
+if "%RefrEnv_debug%"=="yes" (
     echo RefrEnv - Refresh the Environment for CMD - ^(Debug enabled^)
 ) else (
     echo RefrEnv - Refresh the Environment for CMD
@@ -136,7 +149,7 @@ REM set z9
 REM but generally paths and environment variables should not have bad metacharacters, but it is not a rule!
 
 
-if "%debugme%"=="yes" (
+if "%RefrEnv_debug%"=="yes" (
     explorer "%TEMPDir%"
 ) else (
     rmdir /Q /S "%TEMPDir%"
@@ -146,7 +159,7 @@ REM cleanup
 set "TEMPDir="
 set "outputfile="
 set "DelayedExpansionState="
-set "debugme="
+set "RefrEnv_debug="
 
 
 REM pause
@@ -210,8 +223,13 @@ REM next
 REM here we add the actual session path, so we do not reset the original path, because maybe the parent script added some folders to the path, If we need to reset the path then comment the following line
 ProcessPath = oEnvP("PATH")
 
-REM merge System, User, Volatile, and process PATHs
-NewPath = SystemPath & ";" & UserPath & ";" & VolatilePath & ";" & ProcessPath
+REM merge System, User, Volatile, and possibly process PATHs
+If oEnvP("RefrEnv_ResetPath") = "yes" Then
+  NewPath = SystemPath & ";" & UserPath & ";" & VolatilePath
+Else
+  NewPath = SystemPath & ";" & UserPath & ";" & VolatilePath & ";" & ProcessPath
+End If
+
 
 
 REM ________________________________________________________________

--- a/refrenv.ps1
+++ b/refrenv.ps1
@@ -230,23 +230,6 @@ None
 
 #  Write-FunctionCallLogMessage -Invocation $MyInvocation -Parameters $PSBoundParameters
 
-  # $refreshEnv = $false
-  # $invocation = $MyInvocation
-  # if ($invocation.InvocationName -eq 'refreshenv') {
-  #   $refreshEnv = $true
-  # }
-
-  # if ($refreshEnv) {
-  #   Write-Output 'Refreshing environment variables from the registry for powershell.exe. Please wait...'
-  # } else {
-  #   Write-Verbose 'Refreshing environment variables from the registry.'
-  # }
-
-  # $userName = $env:USERNAME
-  # $architecture = $env:PROCESSOR_ARCHITECTURE
-  # $psModulePath = $env:PSModulePath
-
-
   #ordering is important here, $user should override $machine...
   $ScopeList = 'Process', 'Machine'
   #powershell v2 which come preinstalled in win 7 do not have  -notin
@@ -282,8 +265,6 @@ None
     }
   }
 
-  # Get-ChildItem Env:
-
   
   if ($env:RefrEnv_ResetPath -eq 'yes') {
     $scopes = 'Machine', 'User'
@@ -303,13 +284,6 @@ None
   # TODO: should i exclude this? what happens when an app adds a path to PSModulePath in the hklm reg? so i think i should not prevent updating this
   # $env:PSModulePath = $psModulePath
 
-  # reset user and architecture
-  # if ($userName) { $env:USERNAME = $userName; }
-  # if ($architecture) { $env:PROCESSOR_ARCHITECTURE = $architecture; }
-
-  # if ($refreshEnv) {
-  #   Write-Output 'Finished'
-  # }
 }
 
 # Set-Alias refreshenv Update-SessionEnvironment

--- a/refrenv.ps1
+++ b/refrenv.ps1
@@ -1,7 +1,33 @@
 
-# description: refrenv = refresh environment. for powershell
+# author: Badr Elmers 2021-2024
+# version: 1.0
 # https://github.com/badrelmers/RefrEnv
-# usage: . .\refrenv.ps1
+
+<#
+.SYNOPSIS
+    RefrEnv - Refresh the Environment for Powershell/Pwsh
+
+.EXAMPLE
+    . .\refrenv.ps1
+    
+.DESCRIPTION
+    By default with no arguments, this script will do a full 
+    refresh (refresh all non critical variables*, and refresh the PATH).
+
+    you can use the following variables to change the default behaviour:
+                                
+    RefrEnv_ResetPath=yes       Reset the actual PATH inside Powershell, then refresh
+                                it with a new PATH. This will delete any PATH 
+                                added by the script who called RefrEnv. It is 
+                                equivalent to running a new Powershell session.
+
+you can also put this script in windows\systems32 or another place in your %PATH% then call it from an interactive console by writing refrenv.
+
+*critical variables: are variables which belong to Powershell/windows and should not be refreshed normally like:
+  - windows vars:
+    ALLUSERSPROFILE APPDATA CommonProgramFiles CommonProgramFiles(x86) CommonProgramW6432 COMPUTERNAME ComSpec HOMEDRIVE HOMEPATH LOCALAPPDATA LOGONSERVER NUMBER_OF_PROCESSORS OS PATHEXT PROCESSOR_ARCHITECTURE PROCESSOR_ARCHITEW6432 PROCESSOR_IDENTIFIER PROCESSOR_LEVEL PROCESSOR_REVISION ProgramData ProgramFiles ProgramFiles(x86) ProgramW6432 PUBLIC SystemDrive SystemRoot TEMP TMP USERDOMAIN USERDOMAIN_ROAMINGPROFILE USERNAME USERPROFILE windir SESSIONNAME
+
+#>
 
 # based on Chocolatey powershell refreshenv 
 ##################################################################
@@ -288,6 +314,6 @@ None
 
 # Set-Alias refreshenv Update-SessionEnvironment
 
-echo 'RefrEnv - Refresh the Environment for powershell/pwsh'
+echo 'RefrEnv - Refresh the Environment for Powershell/Pwsh'
 
 Update-SessionEnvironment

--- a/refrenv.ps1
+++ b/refrenv.ps1
@@ -4,13 +4,13 @@
 # https://github.com/badrelmers/RefrEnv
 
 <#
-.SYNOPSIS
+NAME
     RefrEnv - Refresh the Environment for Powershell/Pwsh
 
-.EXAMPLE
+SYNOPSIS
     . .\refrenv.ps1
     
-.DESCRIPTION
+DESCRIPTION
     By default with no arguments, this script will do a full 
     refresh (refresh all non critical variables*, and refresh the PATH).
 

--- a/refrenv.sh
+++ b/refrenv.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-# author: Badr Elmers 2021-2023
-# description: RefrEnv = refresh environment. for bash of Cygwin/Msys2/GitBash
+# author: Badr Elmers 2021-2024
 # version: 1.3
 # https://github.com/badrelmers/RefrEnv
-# https://stackoverflow.com/questions/171588/is-there-a-command-to-refresh-environment-variables-from-the-command-prompt-in-w
 
 ###########################################################################################
 
@@ -27,7 +25,7 @@ DESCRIPTION
     By default with no arguments, this script will do a full 
     refresh (refresh all non critical variables*, and refresh the PATH).
 
-    you can use the following variables to change some behaviours:
+    you can use the following variables to change the default behaviour:
     
     RefrEnv_StrictRefresh=yes   Strict mode (secure refresh). this prevent 
                                 refreshing a variable if it is already defined  


### PR DESCRIPTION
- add `RefrEnv_ResetPath` environment variable to allow reset the PATH for CMD and Powershell
- prevent PATH reset by default in Powershell 
- Powershell : prevent the reset of the same dangerous vars we used in batch

fix https://github.com/badrelmers/RefrEnv/issues/6